### PR TITLE
refactor: split routers and handler to separate files

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,9 @@
 import { withTRPC } from '@trpc/next';
 import { AppType } from 'next/dist/shared/lib/utils';
-import { AppRouter } from './api/trpc/[trpc]';
+import { AppRouter } from '../utils/trpc/AppRouter';
 
-const MyApp: AppType = ({ Component, pageProps }) => {
-  return <Component {...pageProps} />;
-};
+const MyApp: AppType = ({ Component, pageProps }) => 
+  <Component {...pageProps} />;
 
 export default withTRPC<AppRouter>({
   config({ ctx }) {

--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -1,22 +1,5 @@
-import * as trpc from '@trpc/server';
 import * as trpcNext from '@trpc/server/adapters/next';
-import { z } from 'zod';
-
-export const appRouter = trpc.router().query('hello', {
-  input: z
-    .object({
-      text: z.string().nullish(),
-    })
-    .nullish(),
-  resolve({ input }) {
-    return {
-      greeting: `hello ${input?.text ?? 'world'}`,
-    };
-  },
-});
-
-// export type definition of API
-export type AppRouter = typeof appRouter;
+import { appRouter } from '../../../utils/trpc/AppRouter';
 
 // export API handler
 export default trpcNext.createNextApiHandler({

--- a/src/utils/trpc/AppRouter.ts
+++ b/src/utils/trpc/AppRouter.ts
@@ -1,0 +1,18 @@
+import * as trpc from '@trpc/server';
+import { z } from 'zod';
+
+export const appRouter = trpc.router().query('hello', {
+  input: z
+    .object({
+      text: z.string().nullish(),
+    })
+    .nullish(),
+  resolve({ input }) {
+    return {
+      greeting: `hello ${input?.text ?? 'world'}`,
+    };
+  },
+});
+
+// export type definition of API
+export type AppRouter = typeof appRouter;

--- a/src/utils/trpc/index.ts
+++ b/src/utils/trpc/index.ts
@@ -1,5 +1,5 @@
 import { createReactQueryHooks } from '@trpc/react';
-import type { AppRouter } from '../pages/api/trpc/[trpc]';
+import type { AppRouter } from './AppRouter';
 
 export const trpc = createReactQueryHooks<AppRouter>();
 // => { useQuery: ..., useMutation: ...}


### PR DESCRIPTION
I don't like adding named exports to nextjs handler files. The only things that should be exported there are the nextjs configs and the default export for the handler